### PR TITLE
the forgotten type

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,6 @@
             <li>C_c_cc</li>
             <li>D_d_dd</li>
         </ol>
-    <script src="script.js"></script>
+    <script type="module" src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
type "module" is required for modular control